### PR TITLE
small refactoring

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,38 +3,11 @@
 'use strict';
 
 var Transform = require('stream').Transform,
-    BufferStreams = require('bufferstreams'),
     SVGOptim = require('svgo'),
     gutil = require('gulp-util');
 
 var PLUGIN_NAME = 'gulp-svgmin';
 
-// File level transform function
-function minifySVGTransform(svgo) {
-
-    if (!(svgo instanceof SVGOptim)) {
-        svgo = new SVGOptim(svgo);
-    }
-
-    // Return a callback function handling the buffered content
-    return function(err, buf, cb) {
-
-        // Handle any error
-        if (err) {
-            cb(new gutil.PluginError(PLUGIN_NAME, err));
-        }
-
-        // Use the buffered content
-        svgo.optimize(String(buf), function(result) {
-            if (result.error) {
-                cb(new gutil.PluginError(PLUGIN_NAME, result.error));
-            }
-
-            // Bring it back to streams
-            cb(null, new Buffer(result.data));
-        });
-    };
-}
 
 // Plugin function
 function minifySVGGulp(plugins) {
@@ -42,35 +15,24 @@ function minifySVGGulp(plugins) {
     var svgo = new SVGOptim({ plugins: plugins });
 
     stream._transform = function(file, unused, done) {
-        // When null just pass through
-        if(file.isNull()) {
-            stream.push(file); done();
-            return;
-        }
+        if (file.isStream()) return done(new gutil.PluginError(PLUGIN_NAME, "Streaming not supported"));
 
-        if (file.isStream()) {
-            file.contents = file.contents.pipe(
-                new BufferStreams(minifySVGTransform(svgo)));
-            stream.push(file);
-            done();
-        } else {
+        if (file.isBuffer()) {
             svgo.optimize(String(file.contents), function(result) {
                 if (result.error) {
-                    stream.emit('error', new gutil.PluginError(PLUGIN_NAME, result.error));
+                    return done(new gutil.PluginError(PLUGIN_NAME, result.error));
                 }
                 file.contents = new Buffer(result.data);
-                stream.push(file);
-                done();
+                done(null, file);
             });
+        } else {
+            // When null just pass through
+            done(null, file);
         }
     };
 
     return stream;
 }
 
-// Export the file level transform function for other plugins usage
-minifySVGGulp.fileTransform = minifySVGTransform;
-
 // Export the plugin main function
 module.exports = minifySVGGulp;
-

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
     "svg"
   ],
   "dependencies": {
-    "svgo": "~0.4.4",
-    "bufferstreams": "0.0.2",
     "gulp-util": "~2.2.6"
   },
+  "peerDependencies": {
+    "svgo": "*"
+  },
   "devDependencies": {
+    "svgo": "~0.4.4",
     "chai": "~1.9.0",
     "clear": "0.0.1",
     "gulp": "~3.5.2",

--- a/test.js
+++ b/test.js
@@ -92,66 +92,27 @@ describe('gulp-svgmin', function() {
 
     });
 
-    describe('stream mode', function() {
-        it('should minify svg with svgo', function(cb) {
-            var stream = svgmin();
-            var fakeFile = new gutil.File({
-                contents: new Stream()
-            });
-        
-            stream.on('data', function(data) {
-                data.contents.pipe(es.wait(function(err, data) {
-                    expect(data).to.equal(compressed);
-                    cb();
-                }));
-            });
-        
+    it('in stream mode must emit error', function(cb) {
+        var stream = svgmin();
+        var fakeFile = new gutil.File({
+            contents: new Stream()
+        });
+
+        stream.on('data', function(data) {
+            data.contents.pipe(es.wait(function(err, data) {
+                expect(data).to.equal(compressed);
+                cb();
+            }));
+        });
+
+        var doWrite = function() {
             stream.write(fakeFile);
             fakeFile.contents.write(raw);
             fakeFile.contents.end();
-        });
-        
-        it('should honor disabling plugins, such as keeping the doctype', function(cb) {
-            var stream = svgmin([{
-                removeDoctype: false
-            }]);
-            var fakeFile = new gutil.File({
-                contents: new Stream()
-            });
-        
-            stream.on('data', function(data) {
-                data.contents.pipe(es.wait(function(err, data) {
-                    expect(data).to.have.string(doctype);
-                    cb();
-                }));
-            });
-        
-            stream.write(fakeFile);
-            fakeFile.contents.write(raw);
-            fakeFile.contents.end();
-        });
+        };
 
-        it('should allow disabling multiple plugins', function(cb) {
-            var stream = svgmin([{
-                removeDoctype: false
-            }, {
-                removeComments: false
-            }]);
-
-            var fakeFile = new gutil.File({
-                contents: new Stream()
-            });
-
-            stream.on('data', function(data) {
-                data.contents.pipe(es.wait(function(err, data) {
-                    expect(data).to.have.string(doctype).and.to.have.string('test comment');
-                    cb();
-                }));
-            });
-
-            stream.write(fakeFile);
-            fakeFile.contents.write(raw);
-            fakeFile.contents.end();
-        });
+        expect(doWrite).to.throw(/Streaming not supported/);
+        cb();
     });
+
 });


### PR DESCRIPTION
* use peer dependency for target dep. svgo in favor of http://blog.nodejs.org/2013/02/07/peer-dependencies/
* don't care about comportability while stream files - user can use gulp-buffer instead