### PR TITLE
Config object format is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ below.
 ```js
 gulp.task('default', function() {
     return gulp.src('logo.svg')
-        .pipe(svgmin({
-            plugins: [{
+        .pipe(svgmin([
+            {
                 removeDoctype: false
             }, {
                 removeComments: false
-            }]
-        }))
+            }
+        ])
         .pipe(gulp.dest('./out'));
 });
 ```


### PR DESCRIPTION
For me, what was in the readme didn't work. I was getting errors that svgo was trying to loop over an obejct. From reading the source, it looks like you expect the plugins passed in, not a config object containing a `plugins` property. I don't know how the tests are passing but it works for me now when I pass the plugins array in as the param.