### PR TITLE
Allow per-file options

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,31 @@ gulp.task('pretty', function () {
 });
 ```
 
+## Per-file options
+
+To have per-file options, pass a function, that receives `file` object and
+returns `svgo` options. For example, if you need to prefix ids with filenames
+to make them unique before combining svgs with [gulp-svgstore](https://github.com/w0rm/gulp-svgstore):
+
+```js
+gulp.task('default', function () {
+    return gulp.src('src/*.svg')
+        .pipe(svgmin(function getOptions (file) {
+            var prefix = path.basename(file.relative, path.extname(file.relative));
+            return {
+                plugins: [{
+                    cleanupIDs: {
+                        prefix: prefix + '-',
+                        minify: true
+                    }
+                }]
+            }
+        }))
+        .pipe(svgstore())
+        .pipe(gulp.dest('./dest'));
+});
+```
+
 ## Contributing
 
 Pull requests are welcome. If you add functionality, then please add unit tests

--- a/index.js
+++ b/index.js
@@ -8,7 +8,11 @@ var Transform = require('stream').Transform,
 
 module.exports = function (options) {
     var stream = new Transform({objectMode: true});
-    var svgo = new SVGOptim(options);
+    var svgo;
+
+    if (typeof options !== 'function') {
+        svgo = new SVGOptim(options);
+    }
 
     stream._transform = function (file, encoding, cb) {
         if (file.isNull()) {
@@ -20,6 +24,11 @@ module.exports = function (options) {
         }
 
         if (file.isBuffer()) {
+
+            if (typeof options === 'function') {
+                svgo = new SVGOptim(options(file));
+            }
+
             svgo.optimize(String(file.contents), function (result) {
                 if (result.error) {
                     return cb(new PluginError(PLUGIN_NAME, result.error));

--- a/test.js
+++ b/test.js
@@ -31,7 +31,6 @@ function makeTest (plugins, content, expected, done) {
 describe('gulp-svgmin', function () {
     it('should let null files pass through', function (done) {
         var stream = svgmin();
-        var i = 0;
 
         stream.on('data', function (data) {
             expect(data.contents).to.equal(null);
@@ -58,6 +57,20 @@ describe('gulp-svgmin', function () {
         makeTest(plugins, raw, function (content) {
             return expect(content).to.contain(doctype);
         }, done);
+    });
+
+    it('should allow per file options, such as keeping the doctype', function (cb) {
+        var file = new gutil.File({contents: new Buffer(raw)});
+        var getOptions = function (f) {
+            expect(f).to.equal(file);
+            return {plugins: [{removeDoctype: false}]};
+        };
+        var stream = svgmin(getOptions);
+        stream.on('data', function (data) {
+            expect(data.contents.toString()).to.contain(doctype);
+            cb();
+        });
+        stream.write(file);
     });
 
     it('should allow disabling multiple plugins', function (done) {


### PR DESCRIPTION
This is a nice way to solve [unique ids problem in gulp-svgstore](https://github.com/w0rm/gulp-svgstore/issues/33) without having to implement a custom transformation stream, or depend on svgo.