### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "svgo"
   ],
   "dependencies": {
-    "gulp-util": "^3.0.4",
+    "plugin-error": "^0.1.2",
     "svgo": "^0.7.0"
   },
   "devDependencies": {
@@ -47,7 +47,8 @@
     "eslint-config-cssnano": "^3.0.0",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-import": "^2.0.1",
-    "nyc": "^10.0.0"
+    "nyc": "^10.0.0",
+    "vinyl": "^2.1.0"
   },
   "eslintConfig": {
     "extends": "cssnano"

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -1,7 +1,7 @@
 import Stream from 'stream';
 import {expect} from 'chai';
 import ava from 'ava';
-import gutil from 'gulp-util';
+import Vinyl from 'vinyl';
 import svgmin from '..';
 
 const head = '<?xml version="1.0" encoding="utf-8"?>';
@@ -22,7 +22,7 @@ function makeTest (plugins, content, expected) {
             resolve();
         });
 
-        stream.write(new gutil.File({contents: new Buffer(content)}));
+        stream.write(new Vinyl({contents: new Buffer(content)}));
     });
 }
 
@@ -35,7 +35,7 @@ ava('should let null files pass through', () => {
             resolve();
         });
 
-        stream.write(new gutil.File({
+        stream.write(new Vinyl({
             path: 'null.md',
             contents: null,
         }));
@@ -69,7 +69,7 @@ ava('should allow disabling multiple plugins', () => {
 
 ava('should allow per file options, such as keeping the doctype', () => {
     return new Promise(resolve => {
-        const file = new gutil.File({contents: new Buffer(raw)});
+        const file = new Vinyl({contents: new Buffer(raw)});
 
         const stream = svgmin(data => {
             expect(data).to.equal(file);
@@ -87,8 +87,8 @@ ava('should allow per file options, such as keeping the doctype', () => {
 
 ava('in stream mode must emit error', (t) => {
     const stream = svgmin();
-    const fakeFile = new gutil.File({
-        contents: new Stream(),
+    const fakeFile = new Vinyl({
+        contents: new Stream.Readable(),
     });
 
     const doWrite = function () {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import {Transform} from 'stream';
 import SVGOptim from 'svgo';
-import {PluginError} from 'gulp-util';
+import PluginError from 'plugin-error';
 
 const PLUGIN_NAME = 'gulp-svgmin';
 


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been recently deprecated. Continuing to use this dependency may prevent the use of your library with the latest release of Gulp 4 so **it is important to replace `gulp-util`**.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143