### PR TITLE
Fix prettier config to match xo config

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "xo": "^0.38.2"
   },
   "prettier": {
+    "bracketSpacing": false,
     "trailingComma": "es5",
     "tabWidth": 4,
     "semi": true,


### PR DESCRIPTION
I'm not sure how this happened but the Prettier config does not match the expect `xo` linting.

Steps to reproduce:

1. Do a fresh git clone of gulp-svgmin
2. `npm install`
3. `npm test` — All tests should pass, including `xo` linting.
4. `npx prettier --write src` — Prettier uses the config from `package.json` and re-writes files.
5. `git status` — Shows multiple files have formatting changes.
6. `npm test` — Tests fail because `xo` linting is failing.
7. `npx xo --fix; git status` — Shows that multiple files were re-written back to what they were when git cloned.

I've updated the prettier config so that IDEs that use Prettier won't break tests.

P.S. I don't like the Prettier options this project is using, but this isn't my project. `¯\_(ツ)_/¯`