### PR TITLE
fix: move lodash.clonedeep to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
         "plugin-error": "^1.0.1",
         "svgo": "^2.3.1"
       },
@@ -20,7 +21,6 @@
         "coveralls": "^3.1.0",
         "cross-env": "^7.0.3",
         "del-cli": "^4.0.0",
-        "lodash.clonedeep": "^4.5.0",
         "nyc": "^15.1.0",
         "prettier": "^2.3.2",
         "vinyl": "^2.2.1",
@@ -8391,8 +8391,7 @@
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -19847,8 +19846,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "svgo"
   ],
   "dependencies": {
+    "lodash.clonedeep": "^4.5.0",
     "plugin-error": "^1.0.1",
     "svgo": "^2.3.1"
   },
@@ -39,7 +40,6 @@
     "coveralls": "^3.1.0",
     "cross-env": "^7.0.3",
     "del-cli": "^4.0.0",
-    "lodash.clonedeep": "^4.5.0",
     "nyc": "^15.1.0",
     "prettier": "^2.3.2",
     "vinyl": "^2.2.1",


### PR DESCRIPTION
This PR addresses missing _lodash.clonedeep_ depency if the gulp-svgmin is used within a project that doesn't include the _lodash.clonedeep_ itself.

Fixes issue #120 